### PR TITLE
Ajouts de certains lieux-dits du cadastre

### DIFF
--- a/lib/compose/extract-lieux-dits.js
+++ b/lib/compose/extract-lieux-dits.js
@@ -1,5 +1,66 @@
-function extractLieuxDits() {
-  return []
+const {findCodePostal} = require('codes-postaux/full')
+
+const {center, feature, featureCollection, truncate} = require('@turf/turf')
+const proj = require('@etalab/project-legal')
+const {chain} = require('lodash')
+
+function buildPositionProps(adresses) {
+  const positions = adresses.filter(a => a.position).map(a => a.position)
+
+  if (positions.length > 0) {
+    const centerFeature = center(featureCollection(positions.map(p => feature(p))))
+    const position = truncate(centerFeature).geometry
+    const [lon, lat] = position.coordinates
+    const [x, y] = proj([lon, lat]) || []
+    return {lon, lat, x, y, position, positionType: 'interpolation'}
+  }
+
+  return {}
+}
+
+function getCodePostal(codeCommune, idVoie, numero, suffixe) {
+  if (idVoie.length === 10) {
+    const [codeCommuneVoie, codeVoie] = idVoie.toUpperCase().split('_')
+    return findCodePostal(codeCommuneVoie, codeVoie, numero, suffixe) || findCodePostal(codeCommuneVoie) || findCodePostal(codeCommune)
+  }
+
+  return findCodePostal(codeCommune)
+}
+
+const ACCEPT_DESTINATIONS = [
+  'habitation',
+  'commerce',
+  'industrie',
+  'tourisme'
+]
+
+function extractLieuxDits(adressesCommune) {
+  const voiesLieuxDits = chain(adressesCommune)
+    .filter(a => a.idVoie)
+    .groupBy('idVoie')
+    .filter(adressesVoie => adressesVoie.every(a => a.numero >= 5000))
+    .map(adressesVoie => {
+      const {codeCommune, idVoie, nomVoie, nomCommune, codeAncienneCommune, nomAncienneCommune} = adressesVoie[0]
+      const codePostalResult = getCodePostal(codeCommune, idVoie) || {}
+
+      return {
+        source: 'cadastre',
+        idVoie,
+        nomVoie,
+        codeCommune,
+        nomCommune,
+        codeAncienneCommune,
+        nomAncienneCommune,
+        destination: chain(adressesVoie).map('destination').flatten().uniq().value(),
+        parcelles: chain(adressesVoie).map('parcelles').flatten().uniq().value(),
+        ...buildPositionProps(adressesVoie),
+        ...codePostalResult,
+        licence: 'lov2'
+      }
+    })
+    .value()
+
+  return voiesLieuxDits.filter(v => v.destination.some(d => ACCEPT_DESTINATIONS.includes(d)))
 }
 
 module.exports = extractLieuxDits

--- a/lib/compose/extract-lieux-dits.js
+++ b/lib/compose/extract-lieux-dits.js
@@ -1,0 +1,5 @@
+function extractLieuxDits() {
+  return []
+}
+
+module.exports = extractLieuxDits

--- a/lib/compose/index.js
+++ b/lib/compose/index.js
@@ -1,6 +1,7 @@
 const {chain} = require('lodash')
 const {CommunesDb} = require('../util/storage')
 const consolidateVoies = require('./consolidate-voies')
+const extractLieuxDits = require('./extract-lieux-dits')
 
 async function main(options) {
   const {codeCommune, productName} = options
@@ -29,7 +30,12 @@ async function main(options) {
     .flatten()
     .value()
 
-  await compositionStorage.setCommune(codeCommune, adressesCommune)
+  const lieuxDits = extractLieuxDits(rawAdressesCommune)
+
+  await compositionStorage.setCommune(codeCommune, {
+    adresses: adressesCommune,
+    lieuxDits
+  })
 
   console.timeEnd(`commune ${codeCommune}`)
 }

--- a/lib/compose/products/adresses-lo.js
+++ b/lib/compose/products/adresses-lo.js
@@ -10,7 +10,10 @@ const SOURCES = [
 ]
 
 function filterAdresses(adressesCommune) {
-  return adressesCommune.filter(a => SOURCES.includes(a.source) && a.licence !== 'odc-odbl')
+  return adressesCommune
+    .filter(a => SOURCES.includes(a.source))
+    .filter(a => a.licence !== 'odc-odbl')
+    .filter(a => a.numero < 5000)
 }
 
 module.exports = {filterAdresses, selectNomVoie, selectPosition}

--- a/lib/compose/products/adresses-odbl.js
+++ b/lib/compose/products/adresses-odbl.js
@@ -12,7 +12,9 @@ const SOURCES = [
 ]
 
 function filterAdresses(adressesCommune) {
-  return adressesCommune.filter(a => SOURCES.includes(a.source))
+  return adressesCommune
+    .filter(a => SOURCES.includes(a.source))
+    .filter(a => a.numero < 5000)
 }
 
 module.exports = {filterAdresses, selectNomVoie, selectPosition}

--- a/lib/distribute/index.js
+++ b/lib/distribute/index.js
@@ -1,4 +1,3 @@
-const {flatten, compact} = require('lodash')
 const debug = require('debug')('adresse-pipeline')
 const {CommunesDb} = require('../util/storage')
 const {getCodesCommunes} = require('../util/cog')

--- a/lib/distribute/index.js
+++ b/lib/distribute/index.js
@@ -8,11 +8,26 @@ async function main({departement, distName, productName, outputPath}) {
   const {writeData} = require(`./writers/${distName}`)
   const db = new CommunesDb(`composition-${productName}`)
 
-  const adresses = flatten(compact(
-    await Promise.all(getCodesCommunes(departement).map(codeCommune => db.getCommune(codeCommune)))
-  ))
+  const departementAdresses = []
+  const departementLieuxDits = []
 
-  await writeData(outputPath, adresses)
+  await Promise.all(getCodesCommunes(departement).map(async codeCommune => {
+    const communeData = await db.getCommune(codeCommune)
+
+    if (!communeData) {
+      return
+    }
+
+    const {adresses, lieuxDits} = communeData
+
+    departementAdresses.push(...adresses)
+    departementLieuxDits.push(...lieuxDits)
+  }))
+
+  await writeData(outputPath, {
+    adresses: departementAdresses,
+    lieuxDits: departementLieuxDits
+  })
 }
 
 module.exports = async function (options, cb) {

--- a/lib/distribute/writers/addok.js
+++ b/lib/distribute/writers/addok.js
@@ -141,7 +141,7 @@ async function expandCommunesWithCenter(codeDepartement) {
   })
 }
 
-async function writeData(path, adresses) {
+async function writeData(path, {adresses}) {
   const codeDepartement = getCodeDepartement(adresses[0].codeCommune)
   await expandCommunesWithCenter(codeDepartement)
   const filteredAdresses = adresses.filter(a => a.lon && a.lat)

--- a/lib/distribute/writers/addok.js
+++ b/lib/distribute/writers/addok.js
@@ -111,25 +111,55 @@ function buildStreet(adressesVoie, addOldCity = false) {
 
   const {lon, lat, x, y} = buildCenterProps(adressesVoie)
 
-  const codeCommuneArrondissement = getPLMCodeCommune(commune.code)
-
   return {
     id: voie.cleInterop.split('_').slice(0, 2).join('_'),
     type: 'street',
-    name: addOldCity && voie.nomAncienneCommune ? `${beautify(voie.nomVoie)} (${voie.nomAncienneCommune})` : beautify(voie.nomVoie),
-    postcode: voie.codePostal,
-    citycode: codeCommuneArrondissement ? [commune.code, codeCommuneArrondissement] : compact([commune.code, voie.codeAncienneCommune]),
-    oldcitycode: voie.codeAncienneCommune,
     lon,
     lat,
     x,
     y,
+    importance: buildImportance(commune.population, adressesVoie.length),
+    housenumbers,
+
+    ...computeCommonVoieProps(voie)
+  }
+}
+
+function computeCommonVoieProps(voie) {
+  const commune = communesIndex[voie.codeCommune]
+  const codeCommuneArrondissement = getPLMCodeCommune(commune.code)
+  const addOldCity = true
+
+  return {
+    id: voie.idVoie,
+    name: addOldCity && voie.nomAncienneCommune ? `${beautify(voie.nomVoie)} (${voie.nomAncienneCommune})` : beautify(voie.nomVoie),
+    postcode: voie.codePostal,
+    citycode: codeCommuneArrondissement ? [commune.code, codeCommuneArrondissement] : compact([commune.code, voie.codeAncienneCommune]),
+    oldcitycode: voie.codeAncienneCommune,
+    lon: voie.lon,
+    lat: voie.lat,
+    x: voie.x,
+    y: voie.y,
     city: compact([getNomCommune(codeCommuneArrondissement), commune.nom, voie.nomAncienneCommune]),
     district: codeCommuneArrondissement ? commune.nom : undefined,
     oldcity: voie.nomAncienneCommune,
     context: buildContext(getCodeDepartement(commune.code)),
-    importance: buildImportance(commune.population, adressesVoie.length),
-    housenumbers
+    importance: buildImportance(commune.population, 1)
+  }
+}
+
+function buildLocalities(lieuxDits) {
+  return lieuxDits.map(ld => buildLocality(ld))
+}
+
+function buildLocality(lieuDit) {
+  const commune = communesIndex[lieuDit.codeCommune]
+
+  return {
+    type: 'locality',
+    importance: buildImportance(commune.population, 1),
+
+    ...computeCommonVoieProps(lieuDit)
   }
 }
 
@@ -141,10 +171,11 @@ async function expandCommunesWithCenter(codeDepartement) {
   })
 }
 
-async function writeData(path, {adresses}) {
+async function writeData(path, {adresses, lieuxDits}) {
   const codeDepartement = getCodeDepartement(adresses[0].codeCommune)
   await expandCommunesWithCenter(codeDepartement)
   const filteredAdresses = adresses.filter(a => a.lon && a.lat)
+  const filteredLieuxDits = lieuxDits.filter(a => a.lon && a.lat)
 
   const adressesCommunes = groupBy(filteredAdresses, 'codeCommune')
   const missingCommunes = communes.filter(c => c.departement === codeDepartement && !(c.code in adressesCommunes))
@@ -154,6 +185,7 @@ async function writeData(path, {adresses}) {
     intoStream.object(
       missingCommunes.map(commune => buildMunicipality(commune))
         .concat(buildStreets(filteredAdresses))
+        .concat(buildLocalities(filteredLieuxDits))
     ),
     stringify()
   ]

--- a/lib/distribute/writers/addok.js
+++ b/lib/distribute/writers/addok.js
@@ -93,7 +93,7 @@ function buildCommuneStreets(adressesCommune) {
     .concat([municipality])
 }
 
-function buildStreet(adressesVoie, addOldCity = false) {
+function buildStreet(adressesVoie, forceAddOldCity = false) {
   const [voie] = adressesVoie
   const commune = communesIndex[voie.codeCommune]
   const housenumbers = fromPairs(adressesVoie.map(adresse => {
@@ -121,18 +121,17 @@ function buildStreet(adressesVoie, addOldCity = false) {
     importance: buildImportance(commune.population, adressesVoie.length),
     housenumbers,
 
-    ...computeCommonVoieProps(voie)
+    ...computeCommonVoieProps(voie, forceAddOldCity)
   }
 }
 
-function computeCommonVoieProps(voie) {
+function computeCommonVoieProps(voie, forceAddOldCity = false) {
   const commune = communesIndex[voie.codeCommune]
   const codeCommuneArrondissement = getPLMCodeCommune(commune.code)
-  const addOldCity = true
 
   return {
     id: voie.idVoie,
-    name: addOldCity && voie.nomAncienneCommune ? `${beautify(voie.nomVoie)} (${voie.nomAncienneCommune})` : beautify(voie.nomVoie),
+    name: forceAddOldCity && voie.nomAncienneCommune ? `${beautify(voie.nomVoie)} (${voie.nomAncienneCommune})` : beautify(voie.nomVoie),
     postcode: voie.codePostal,
     citycode: codeCommuneArrondissement ? [commune.code, codeCommuneArrondissement] : compact([commune.code, voie.codeAncienneCommune]),
     oldcitycode: voie.codeAncienneCommune,
@@ -159,7 +158,7 @@ function buildLocality(lieuDit) {
     type: 'locality',
     importance: buildImportance(commune.population, 1),
 
-    ...computeCommonVoieProps(lieuDit)
+    ...computeCommonVoieProps(lieuDit, true)
   }
 }
 

--- a/lib/distribute/writers/csv.js
+++ b/lib/distribute/writers/csv.js
@@ -62,7 +62,7 @@ function adresseToRow(a) {
   }
 }
 
-async function writeData(path, adresses) {
+async function writeData(path, {adresses}) {
   await ensureFile(path)
   const steps = [
     intoStream.object(adresses.filter(a => a.position).map(adresseToRow)),

--- a/lib/merge/index.js
+++ b/lib/merge/index.js
@@ -36,11 +36,6 @@ async function main(options) {
       return false
     }
 
-    // Suppression des pseudo-numéros
-    if (Number.parseInt(a.numero, 10) >= 5000) {
-      return false
-    }
-
     // Suppression des lignes dont la source ne correspond pas
     if (filterSources && !filterSources.includes(a.source)) {
       return false


### PR DESCRIPTION
Les numéros virtuels (supérieurs à 5000) ne sortent pas dans les fichiers consolidés.
Cela a pour conséquence la perte des voies qui ne contiennent que des numéros virtuels.

Si évidemment dans de nombreux cas, ces voies n'ont pas d'intérêt, pour les villages mal ou peu adressés, ce sont les seuls informations disponibles.

Cette PR produit une voie de type "locality" dès lors que toutes les adresses de cette voie sont virtuelles.

Cette PR n'a d'impact que sur les fichiers addok.

Les toponymes issus des BAL seront ajoutés dans une PR ultérieure.