### PR TITLE
Added prefix to new ban-id api routes

### DIFF
--- a/lib/api/routes.js
+++ b/lib/api/routes.js
@@ -1,0 +1,18 @@
+
+import express from 'express'
+
+import addressRoutes from './address/routes.js'
+import commonToponymRoutes from './common-toponym/routes.js'
+import districtRoutes from './district/routes.js'
+import statusRoutes from './job-status/routes.js'
+import banIdRoutes from './ban-id/routes.js'
+
+const app = new express.Router()
+
+app.use('/address', addressRoutes)
+app.use('/common-toponym', commonToponymRoutes)
+app.use('/district', districtRoutes)
+app.use('/job-status', statusRoutes)
+app.use('/ban-id', banIdRoutes)
+
+export default app

--- a/server.js
+++ b/server.js
@@ -5,12 +5,7 @@ import morgan from 'morgan'
 import cors from 'cors'
 import mongo from './lib/util/mongo.cjs'
 
-import addressRoutes from './lib/api/address/routes.js'
-import commonToponymRoutes from './lib/api/common-toponym/routes.js'
-import districtRoutes from './lib/api/district/routes.js'
-import statusRoutes from './lib/api/job-status/routes.js'
-import banIdRoutes from './lib/api/ban-id/routes.js'
-
+import apiRoutes from './lib/api/routes.js'
 import legacyRoutes from './lib/api/legacy-routes.cjs'
 
 async function main() {
@@ -29,11 +24,7 @@ async function main() {
   })
 
   app.use('/', legacyRoutes)
-  app.use('/address', addressRoutes)
-  app.use('/common-toponym', commonToponymRoutes)
-  app.use('/district', districtRoutes)
-  app.use('/job-status', statusRoutes)
-  app.use('/ban-id', banIdRoutes)
+  app.use('/api', apiRoutes)
 
   const port = process.env.PORT || 5000
 


### PR DESCRIPTION
This PR aims to add a prefix to all new ban-id API routes.
The chosen prefix is the following one : `/api`

As a consequence, all previous routes (not in use for the moment) are modified. Example : 

before : GET `https://plateforme.adresse.data.gouv.fr/ban-id` ==> after : GET `https://plateforme.adresse.data.gouv.fr/api/ban-id`

fix #217 