### PR TITLE
package: upate validateur-bal 3.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@ban-team/fantoir": "^0.15.0",
     "@ban-team/gazetteer": "^3.2.0",
     "@ban-team/shared-data": "^1.4.2",
-    "@ban-team/validateur-bal": "^3.1.12",
+    "@ban-team/validateur-bal": "^3.2.0",
     "@etalab/adresses-util": "^0.8.2",
     "@etalab/decoupage-administratif": "^5.0.0",
     "@etalab/majic": "^0.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1101,10 +1101,10 @@
   resolved "https://registry.yarnpkg.com/@ban-team/shared-data/-/shared-data-1.4.2.tgz#feb0a4e9aaa026cf1db39b99f8b4dda987682006"
   integrity sha512-GBdEmqIJEcx89EKq+PkyL2YR7hfoiKyDlfNy/vob0N5ro4pCdKZ9cMfPvod35FSC9KOEwaUZuOJz5fFwfSqufA==
 
-"@ban-team/validateur-bal@^3.1.12":
-  version "3.1.12"
-  resolved "https://registry.yarnpkg.com/@ban-team/validateur-bal/-/validateur-bal-3.1.12.tgz#3b04ff6ea279e4c5392b13efb2dedd61fcbde02c"
-  integrity sha512-OcVKjZVjgWZ2kNX2CAfkf2+QG+togiAbF9PDhmWdUO2+a3PNj1l61Pd+fRQm8+SN7OXdE6VJ+5LnCsewWgCoow==
+"@ban-team/validateur-bal@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@ban-team/validateur-bal/-/validateur-bal-3.2.0.tgz#889f188caf87eb5b852465e5a533a8a940d8f225"
+  integrity sha512-fRrxksPXGKWXqpbz0TGo5EpmVXm2mB32JueY8Qxfuwtq3xcZLjZ3PUN1UbCU7yFTAXpRBDIVD2Rq80DxoCp+ZQ==
   dependencies:
     "@ban-team/adresses-util" "^0.9.0"
     "@ban-team/shared-data" "^1.4.2"


### PR DESCRIPTION
## What's Changed in package validator-bal 3.2.0

* fix: ancienCodes lost when building communesIndex by @MaGOs92 in https://github.com/BaseAdresseNationale/validateur-bal/pull/122
* fix: delete ancienne commune minicog by @fufeck in https://github.com/BaseAdresseNationale/validateur-bal/pull/123
* fix: bug longlat_vides no detected when numero zero by @fufeck in https://github.com/BaseAdresseNationale/validateur-bal/pull/124
* feat: remediation toponyme_id with code fantoir by @fufeck in https://github.com/BaseAdresseNationale/validateur-bal/pull/125