### PR TITLE
Fix migration file : update datanova

### DIFF
--- a/db-migrations/migrations/20250514104233-update-datanova.cjs
+++ b/db-migrations/migrations/20250514104233-update-datanova.cjs
@@ -126,9 +126,6 @@ module.exports = {
     const transaction = await queryInterface.sequelize.transaction()
     try {
       await queryInterface.dropTable({schema: 'external', tableName: 'datanova'}, {transaction})
-
-      await queryInterface.sequelize.query('DROP SCHEMA IF EXISTS external CASCADE', {transaction})
-
       await transaction.commit()
     } catch (error) {
       await transaction.rollback()


### PR DESCRIPTION
Suppression de la ligne qui supprimait le schéma `external` lors du `migrate:undo`.
Cette ligne créait une incohérence lorsqu'on parcourait les scripts de migrations.