### PR TITLE
Ajout d'un filtre pour les communes fusionnées

### DIFF
--- a/lib/api/address/utils.js
+++ b/lib/api/address/utils.js
@@ -1,6 +1,6 @@
-import {checkDataFormat, dataValidationReportFrom, checkIdsIsUniq, checkIdsIsVacant, checkIdsIsAvailable, checkDataShema, checkIdsShema, checkIfCommonToponymsExist, checkIfDistrictsExist} from '../helper.js'
+import {checkDataFormat, dataValidationReportFrom, checkIdsIsUniq, checkIdsIsVacant, checkIdsIsAvailable, checkDataShema, checkIdsShema, checkIfCommonToponymsExist, checkIfDistrictsExist, canTransferIdsToChild} from '../helper.js'
 import {banID} from '../schema.js'
-import {getCogFromDistrictID, isAuthorizedCog} from '../district/models.js'
+import {getCogFromDistrictID, getDistrictsFromCog, isAuthorizedCog} from '../district/models.js'
 import {getAddressesByFilters} from './models.js'
 import {banAddressSchema} from './schema.js'
 
@@ -99,6 +99,8 @@ export const getDeltaReport = async (addressIDsWithHash, districtID) => {
   const existingAddresses = await getAddressesByFilters({id: addressIDs}, ['id', 'meta', 'isActive', 'districtID'])
   const existingAddressesMap = new Map(existingAddresses.map(({id, meta, isActive, districtID}) => [id, {hash: meta?.idfix?.hash, isActive, districtID}]))
   const currentCog = await getCogFromDistrictID(districtID)
+  const districtsFromCog = await getDistrictsFromCog(currentCog)
+  const districtMap = new Map(districtsFromCog.map(d => [d.id, d]))
   const isCurrentCogAuthorized = await isAuthorizedCog(currentCog)
 
   for (const {id, hash} of addressIDsWithHash) {
@@ -117,7 +119,9 @@ export const getDeltaReport = async (addressIDsWithHash, districtID) => {
         const isSameDepartment = currentCog.slice(0, sliceLength) === existingCog.slice(0, sliceLength)
 
         // Les DEUX COG doivent être autorisés ET dans le même département
-        if (isCurrentCogAuthorized && isExistingCogAuthorized && isSameDepartment) {
+        // OU  la commune mère peut transmettre ses ids à la commune fille est vrai
+        if ((isCurrentCogAuthorized && isExistingCogAuthorized && isSameDepartment)
+          || canTransferIdsToChild(districtMap, existingAddresseDistrictID, districtID)) {
           idsToUpdate.push(id)
         } else {
           idsUnauthorized.push(id)

--- a/lib/api/common-toponym/utils.js
+++ b/lib/api/common-toponym/utils.js
@@ -1,6 +1,6 @@
-import {checkDataFormat, dataValidationReportFrom, checkIdsIsUniq, checkIdsIsVacant, checkIdsIsAvailable, checkDataShema, checkIdsShema, checkIfDistrictsExist} from '../helper.js'
+import {checkDataFormat, dataValidationReportFrom, checkIdsIsUniq, checkIdsIsVacant, checkIdsIsAvailable, checkDataShema, checkIdsShema, checkIfDistrictsExist, canTransferIdsToChild} from '../helper.js'
 import {banID} from '../schema.js'
-import {getCogFromDistrictID, isAuthorizedCog} from '../district/models.js'
+import {getCogFromDistrictID, getDistrictsFromCog, isAuthorizedCog} from '../district/models.js'
 import {getCommonToponymsByFilters} from './models.js'
 import {banCommonToponymSchema} from './schema.js'
 
@@ -91,7 +91,10 @@ export const getDeltaReport = async (commonToponymIDsWithHash, districtID) => {
   const existingCommonToponyms = await getCommonToponymsByFilters({id: commonToponymIDs}, ['id', 'meta', 'isActive', 'districtID'])
   const existingCommonToponymsMap = new Map(existingCommonToponyms.map(({id, meta, isActive, districtID}) => [id, {hash: meta?.idfix?.hash, isActive, districtID}]))
   const currentCog = await getCogFromDistrictID(districtID)
+  const districtsFromCog = await getDistrictsFromCog(currentCog)
+  const districtMap = new Map(districtsFromCog.map(d => [d.id, d]))
   const isCurrentCogAuthorized = await isAuthorizedCog(currentCog)
+
   for (const {id, hash} of commonToponymIDsWithHash) {
     if (existingCommonToponymsMap.has(id)) {
       const existingCommonToponymDistrictID = existingCommonToponymsMap.get(id).districtID
@@ -111,7 +114,9 @@ export const getDeltaReport = async (commonToponymIDsWithHash, districtID) => {
         const isSameDepartment = currentCog.slice(0, sliceLength) === existingCog.slice(0, sliceLength)
 
         // Les DEUX COG doivent être autorisés ET dans le même département
-        if (isCurrentCogAuthorized && isExistingCogAuthorized && isSameDepartment) {
+        if ((isCurrentCogAuthorized && isExistingCogAuthorized && isSameDepartment)
+        // OU  la commune mère peut transmettre ses ids à la commune fille est vrai
+          || canTransferIdsToChild(districtMap, existingCommonToponymDistrictID, districtID)) {
           idsToUpdate.push(id)
         } else {
           idsUnauthorized.push(id)

--- a/lib/api/district/__mocks__/district-models.js
+++ b/lib/api/district/__mocks__/district-models.js
@@ -4,6 +4,10 @@ export async function getDistricts(districtIDs) {
   return bddDistrictMock.filter(({id}) => districtIDs.includes(id))
 }
 
+export async function getDistrictsFromCog(cog) {
+  return bddDistrictMock.filter(district => district.meta?.insee?.cog === cog || district.meta?.insee?.mainCog === cog)
+}
+
 export async function getCogFromDistrictID(districtID) {
   const district = bddDistrictMock.find(({id}) => id === districtID)
   return district ? district.meta?.insee?.cog : null

--- a/lib/api/helper.js
+++ b/lib/api/helper.js
@@ -179,3 +179,13 @@ export const handleAPIResponse = (res, status, message, response) => {
     response,
   })
 }
+
+export function canTransferIdsToChild(districtMap, parentDistrictId, childDistrictId) {
+  // Parent district that the data is already stored in db
+  const parentDistrictInfo = districtMap.get(parentDistrictId)
+  // Child district that is revendicating ids
+  const childDistrictInfo = districtMap.get(childDistrictId)
+  return parentDistrictInfo?.meta?.insee?.isMain === false
+        && childDistrictInfo?.meta?.insee?.isMain === true
+        && parentDistrictInfo?.meta?.insee?.mainId === childDistrictId
+}


### PR DESCRIPTION
Permet à une commune issues de la fusions d'autres communes déjà en base, de récupérer les identifiants d'adresse et de toponymes des communes mères lors de la publication de la BAL, évitant ainsi un blocage de la BAL.