### PR TITLE
Modif url api-depot

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -29,7 +29,7 @@ PORT=5000
 EXPORT_TO_EXPLOITATION_DB_JOB_DELAY=10000 # Time in ms during which an export job is delayed before being processed 
 
 # API de dépôt
-API_DEPOT_URL=https://plateforme.adresse.data.gouv.fr/api-depot
+API_DEPOT_URL=https://plateforme-bal.adresse.data.gouv.fr/api-depot
 
 # API ID-Fix
 API_IDFIX_URL=https://plateforme.adresse.data.gouv.fr/api-idfix

--- a/lib/api/alerts/statuts-communes.js
+++ b/lib/api/alerts/statuts-communes.js
@@ -5,7 +5,7 @@ import {getLatestAlerts, getLatestWarnings, getAlertStatusForRevisionsBatch, reg
 const require = createRequire(import.meta.url)
 const fetchWithProxy = require('../../util/fetch.cjs')
 
-const API_DEPOT_URL = (process.env.API_DEPOT_URL || 'https://plateforme.adresse.data.gouv.fr/api-depot').trim()
+const API_DEPOT_URL = (process.env.API_DEPOT_URL || 'https://plateforme-bal.adresse.data.gouv.fr/api-depot').trim()
 const MAX_COGS = 1000
 /** Cache /current-revisions, TTL 10 min. */
 const CURRENT_REVISIONS_CACHE_TTL_MS = (Number(process.env.STATUTS_COMMUNES_CACHE_TTL_MINUTES) || 10) * 60 * 1000

--- a/lib/util/api-depot.cjs
+++ b/lib/util/api-depot.cjs
@@ -1,7 +1,7 @@
 const process = require('process')
 const fetch = require('./fetch.cjs')
 
-const API_DEPOT_URL = process.env.API_DEPOT_URL || 'https://plateforme.adresse.data.gouv.fr/api-depot'
+const API_DEPOT_URL = process.env.API_DEPOT_URL || 'https://plateforme-bal.adresse.data.gouv.fr/api-depot'
 
 async function getCurrentRevision(codeCommune) {
   try {


### PR DESCRIPTION
Nous avons constaté suite à la migration que l'accès à l'api-depot correspondait à https://plateforme.adresse.gouv.fr/api-depot/ redirigé vers https://plateforme-bal.adresse.data.gouv.fr/api-depot.
Cette redirection n'a pas été reprise lors de la redirection. Cette PR corrige ces redirections

Après le merge il faudra modifier la variable d'environnement